### PR TITLE
Alq666/purge

### DIFF
--- a/recipes/purge.rb
+++ b/recipes/purge.rb
@@ -17,6 +17,11 @@
 # limitations under the License.
 #
 
+service 'ossec' do
+  supports :start => true, :stop => true, :restart => true, :status => true
+  action :none
+end
+
 # Stop service
 # Fake the restart to avoid the delayed notification
 ruby_block 'stop service' do

--- a/recipes/purge.rb
+++ b/recipes/purge.rb
@@ -18,7 +18,7 @@
 #
 
 service 'ossec' do
-  supports :start => true, :stop => true, :restart => true, :status => true
+  supports :start => true, :stop => true, :disable => true, :status => true
   action :none
 end
 


### PR DESCRIPTION
Define the service to avoid `Cannot find a resource matching service[ossec] (did you define it first?)`
