### PR TITLE
Override ossec_rules.xml to disable netstat check

### DIFF
--- a/files/default/rules/ossec_rules.xml
+++ b/files/default/rules/ossec_rules.xml
@@ -1,0 +1,369 @@
+<!-- @(#) $Id: ./etc/rules/ossec_rules.xml, 2012/03/30 dcid Exp $
+
+  -  Official ossec rules for OSSEC.
+  -
+  -  Copyright (C) 2009 Trend Micro Inc.
+  -  All rights reserved.
+  -
+  -  This program is a free software; you can redistribute it
+  -  and/or modify it under the terms of the GNU General Public
+  -  License (version 2) as published by the FSF - Free Software
+  -  Foundation.
+  -
+  -  License details: http://www.ossec.net/en/licensing.html
+  -->
+
+
+
+<group name="ossec,">
+  <rule id="500" level="0">
+    <category>ossec</category>
+    <decoded_as>ossec</decoded_as>
+    <description>Grouping of ossec rules.</description>
+  </rule>
+
+  <rule id="501" level="3">
+    <if_sid>500</if_sid>
+    <if_fts />
+    <options>alert_by_email</options>
+    <match>Agent started</match>
+    <description>New ossec agent connected.</description>
+  </rule>
+
+  <rule id="502" level="3">
+    <if_sid>500</if_sid>
+    <options>alert_by_email</options>
+    <match>Ossec started</match>
+    <description>Ossec server started.</description>
+  </rule>
+
+  <rule id="503" level="3">
+    <if_sid>500</if_sid>
+    <options>alert_by_email</options>
+    <match>Agent started</match>
+    <description>Ossec agent started.</description>
+  </rule>
+
+  <rule id="504" level="3">
+    <if_sid>500</if_sid>
+    <options>alert_by_email</options>
+    <match>Agent disconnected</match>
+    <description>Ossec agent disconnected.</description>
+  </rule>
+
+  <rule id="509" level="0">
+    <category>ossec</category>
+    <decoded_as>rootcheck</decoded_as>
+    <description>Rootcheck event.</description>
+    <group>rootcheck,</group>
+  </rule>
+
+  <rule id="510" level="7">
+    <if_sid>509</if_sid>
+    <description>Host-based anomaly detection event (rootcheck).</description>
+    <group>rootcheck,</group>
+    <if_fts />
+  </rule>
+
+  <rule id="511" level="0">
+    <if_sid>510</if_sid>
+    <match>^NTFS Alternate data stream found</match>
+    <regex>Thumbs.db:encryptable'.|:Zone.Identifier'.|</regex>
+    <regex>Exchsrvr/Mailroot/vsi</regex>
+    <description>Ignored common NTFS ADS entries.</description>
+    <group>rootcheck,</group>
+  </rule>
+
+  <rule id="512" level="3">
+    <if_sid>510</if_sid>
+    <match>^Windows Audit</match>
+    <description>Windows Audit event.</description>
+    <group>rootcheck,</group>
+  </rule>
+
+  <rule id="513" level="9">
+    <if_sid>510</if_sid>
+    <match>^Windows Malware</match>
+    <description>Windows malware detected.</description>
+    <group>rootcheck,</group>
+  </rule>
+
+  <rule id="514" level="2">
+    <if_sid>510</if_sid>
+    <match>^Application Found</match>
+    <description>Windows application monitor event.</description>
+    <group>rootcheck,</group>
+  </rule>
+
+  <rule id="515" level="0">
+    <if_sid>510</if_sid>
+    <match>^Starting rootcheck scan|^Ending rootcheck scan.|</match>
+    <match>^Starting syscheck scan|^Ending syscheck scan.</match>
+    <description>Ignoring rootcheck/syscheck scan messages.</description>
+    <group>rootcheck,syscheck</group>
+  </rule>
+
+  <rule id="516" level="3">
+    <if_sid>510</if_sid>
+    <match>^System Audit</match>
+    <description>System Audit event.</description>
+    <group>rootcheck,</group>
+  </rule>
+
+  <rule id="518" level="9">
+    <if_sid>514</if_sid>
+    <match>Adware|Spyware</match>
+    <description>Windows Adware/Spyware application found.</description>
+    <group>rootcheck,</group>
+  </rule>
+
+  <rule id="519" level="7">
+    <if_sid>516</if_sid>
+    <match>^System Audit: Web vulnerability</match>
+    <description>System Audit: Vulnerable web application found.</description>
+    <group>rootcheck,</group>
+  </rule>
+
+  <!-- Process monitoring rules -->
+  <rule id="530" level="0">
+    <if_sid>500</if_sid>
+    <match>^ossec: output: </match>
+    <description>OSSEC process monitoring rules.</description>
+    <group>process_monitor,</group>
+  </rule>
+
+  <rule id="531" level="7" ignore="7200">
+    <if_sid>530</if_sid>
+    <match>ossec: output: 'df -P': /dev/</match>
+    <regex>100%</regex>
+    <description>Partition usage reached 100% (disk space monitor).</description>
+    <group>low_diskspace,</group>
+  </rule>
+
+ <rule id="532" level="0">
+    <if_sid>531</if_sid>
+    <match>cdrom|/media|usb|/mount|floppy|dvd</match>
+    <description>Ignoring external medias.</description>
+  </rule>
+
+
+<!--
+  Disabling the netstat rule because it does not scale well for machines with many
+  open connections.
+
+  <rule id="533" level="7">
+    <if_sid>530</if_sid>
+    <match>ossec: output: 'netstat -tan</match>
+    <check_diff />
+    <description>Listened ports status (netstat) changed (new port opened or closed).</description>
+  </rule>
+  -->
+
+
+  <rule id="534" level="1">
+    <if_sid>530</if_sid>
+    <match>ossec: output: 'w'</match>
+    <check_diff />
+    <options>no_log</options>
+    <description>List of logged in users. It will not be alerted by default.</description>
+  </rule>
+
+  <rule id="535" level="1">
+    <if_sid>530</if_sid>
+    <match>ossec: output: 'last -n </match>
+    <check_diff />
+    <options>no_log</options>
+    <description>List of the last logged in users.</description>
+  </rule>
+
+  <rule id="550" level="7">
+    <category>ossec</category>
+    <decoded_as>syscheck_integrity_changed</decoded_as>
+    <description>Integrity checksum changed.</description>
+    <group>syscheck,</group>
+  </rule>
+
+  <rule id="551" level="7">
+    <category>ossec</category>
+    <decoded_as>syscheck_integrity_changed_2nd</decoded_as>
+    <description>Integrity checksum changed again (2nd time).</description>
+    <group>syscheck,</group>
+  </rule>
+
+  <rule id="552" level="7">
+    <category>ossec</category>
+    <decoded_as>syscheck_integrity_changed_3rd</decoded_as>
+    <description>Integrity checksum changed again (3rd time).</description>
+    <group>syscheck,</group>
+  </rule>
+
+  <rule id="553" level="7">
+    <category>ossec</category>
+    <decoded_as>syscheck_deleted</decoded_as>
+    <description>File deleted. Unable to retrieve checksum.</description>
+    <group>syscheck,</group>
+  </rule>
+
+  <rule id="554" level="0">
+    <category>ossec</category>
+    <decoded_as>syscheck_new_entry</decoded_as>
+    <description>File added to the system.</description>
+    <group>syscheck,</group>
+  </rule>
+
+  <rule id="555" level="7">
+    <if_sid>500</if_sid>
+    <match>^ossec: agentless: </match>
+    <description>Integrity checksum for agentless device changed.</description>
+    <group>syscheck,agentless</group>
+  </rule>
+
+  <!-- Hostinfo rules -->
+  <rule id="580" level="8">
+    <category>ossec</category>
+    <decoded_as>hostinfo_modified</decoded_as>
+    <description>Host information changed.</description>
+    <group>hostinfo,</group>
+  </rule>
+
+  <rule id="581" level="8">
+    <category>ossec</category>
+    <decoded_as>hostinfo_new</decoded_as>
+    <description>Host information added.</description>
+    <group>hostinfo,</group>
+  </rule>
+
+
+  <!-- File rotation/reducded rules -->
+  <rule id="591" level="3">
+    <if_sid>500</if_sid>
+    <match>^ossec: File rotated </match>
+    <description>Log file rotated.</description>
+  </rule>
+
+  <rule id="592" level="8">
+    <if_sid>500</if_sid>
+    <match>^ossec: File size reduced</match>
+    <description>Log file size reduced.</description>
+    <group>attacks,</group>
+  </rule>
+
+  <rule id="593" level="9">
+    <if_sid>500</if_sid>
+    <match>^ossec: Event log cleared</match>
+    <description>Microsoft Event log cleared.</description>
+    <group>logs_cleared,</group>
+  </rule>
+
+  <rule id="594" level="5">
+    <category>ossec</category>
+    <if_sid>550</if_sid>
+    <hostname>syscheck-registry</hostname>
+    <group>syscheck,</group>
+    <description>Registry Integrity Checksum Changed</description>
+  </rule>
+
+  <rule id="595" level="5">
+    <category>ossec</category>
+    <if_sid>551</if_sid>
+    <hostname>syscheck-registry</hostname>
+    <group>syscheck,</group>
+    <description>Registry Integrity Checksum Changed Again (2nd time)</description>
+  </rule>
+
+  <rule id="596" level="5">
+    <category>ossec</category>
+    <if_sid>552</if_sid>
+    <hostname>syscheck-registry</hostname>
+    <group>syscheck,</group>
+    <description>Registry Integrity Checksum Changed Again (3rd time)</description>
+  </rule>
+
+  <rule id="597" level="5">
+    <category>ossec</category>
+    <if_sid>553</if_sid>
+    <hostname>syscheck-registry</hostname>
+    <group>syscheck,</group>
+    <description>Registry Entry Deleted. Unable to Retrieve Checksum</description>
+  </rule>
+
+  <rule id="598" level="5">
+    <category>ossec</category>
+    <if_sid>554</if_sid>
+    <hostname>syscheck-registry</hostname>
+    <group>syscheck,</group>
+    <description>Registry Entry Added to the System</description>
+  </rule>
+
+<!-- active response rules
+Example:
+Sat May  7 03:27:57 CDT 2011 /var/ossec/active-response/bin/firewall-drop.sh delete - 172.16.0.1 1304756247.60385 31151
+-->
+
+  <rule id="600" level="0">
+    <decoded_as>ar_log</decoded_as>
+    <description>Active Response Messages Grouped</description>
+    <group>active_response,</group>
+  </rule>
+
+  <rule id="601" level="3">
+    <if_sid>600</if_sid>
+    <action>firewall-drop.sh</action>
+    <status>add</status>
+    <description>Host Blocked by firewall-drop.sh Active Response</description>
+    <group>active_response,</group>
+  </rule>
+
+  <rule id="602" level="3">
+    <if_sid>600</if_sid>
+    <action>firewall-drop.sh</action>
+    <status>delete</status>
+    <description>Host Unblocked by firewall-drop.sh Active Response</description>
+    <group>active_response,</group>
+  </rule>
+
+  <rule id="603" level="3">
+    <if_sid>600</if_sid>
+    <action>host-deny.sh</action>
+    <status>add</status>
+    <description>Host Blocked by host-deny.sh Active Response</description>
+    <group>active_response,</group>
+  </rule>
+
+  <rule id="604" level="3">
+    <if_sid>600</if_sid>
+    <action>host-deny.sh</action>
+    <status>delete</status>
+    <description>Host Unblocked by host-deny.sh Active Response</description>
+    <group>active_response,</group>
+  </rule>
+
+  <rule id="605" level="3">
+    <if_sid>600</if_sid>
+    <action>route-null.sh</action>
+    <status>add</status>
+    <description>Host Blocked by route-null.sh Active Response</description>
+    <group>active_response,</group>
+  </rule>
+
+  <rule id="606" level="3">
+    <if_sid>600</if_sid>
+    <action>route-null.sh</action>
+    <status>delete</status>
+    <description>Host Unblocked by route-null.sh Active Response</description>
+    <group>active_response,</group>
+  </rule>
+
+  <rule id="700" level="0">
+    <category>ossec</category>
+    <decoded_as>ossec-logcollector</decoded_as>
+    <description>Logcollector Messages Grouped</description>
+  </rule>
+
+  <rule id="701" level="0">
+    <if_sid>700</if_sid>
+    <match>INFO: </match>
+    <description>Ignore informational messages (usually at startup)</description>
+  </rule>
+
+</group> <!-- OSSEC -->

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -45,6 +45,8 @@ execute "tar zxvf #{ossec_dir}.tar.gz" do
   creates "#{Chef::Config[:file_cache_path]}/#{ossec_dir}"
 end
 
+include_recipe 'ossec::rules'
+
 template "#{Chef::Config[:file_cache_path]}/#{ossec_dir}/etc/preloaded-vars.conf" do
   source "preloaded-vars.conf.erb"
   variables :ossec => node['ossec']['user']

--- a/recipes/rules.rb
+++ b/recipes/rules.rb
@@ -1,0 +1,33 @@
+#
+# Cookbook Name:: ossec
+# Recipe:: rule_overrides
+#
+# Copyright 2010, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Add or override rules from cookbook files. This is run after the
+# default ossec-hids are installed.
+
+[
+  'ossec_rules.xml'
+].each do |rule_file|
+  cookbook_file "#{node['ossec']['user']['dir']}/rules/#{rule_file}" do
+    source "rules/#{rules_file}"
+    owner "root"
+    group "ossec"
+    mode 0440
+    notifies :restart, 'service[ossec]'
+  end
+end


### PR DESCRIPTION
This includes a [netstat check](https://github.com/ossec/ossec-hids/blob/master/etc/rules/ossec_rules.xml#L149) that uses a good chunk of CPU on hosts that have many active connections. We were seeing spikes up to 60-80% CPU which hurts the main service running on machines.